### PR TITLE
Fix bug on django testing module

### DIFF
--- a/backend/src/dutch_broomstick/models.py
+++ b/backend/src/dutch_broomstick/models.py
@@ -1,7 +1,7 @@
 import random
 import string
 from django.contrib.auth.models import User
-from django.db import models
+from django.db import models, utils
 
 # Create your models here.
 class Profile(models.Model):
@@ -16,7 +16,8 @@ def random_url(length=7):
         url = "".join([random.choice(string.ascii_lowercase) for _ in range(length)])
         try:
             Room.objects.get(url=url)
-        except Room.DoesNotExist:
+        except (utils.OperationalError, Room.DoesNotExist):
+            # db.utils.OperationalError : no such column while migrating
             return url
 
 


### PR DESCRIPTION
- 마이그레이션 과정에서 Room.url에 접근하지 못해 random_url() 함수에서 발생하는 오류는 단순하게 DB 관련 오류가 발생시 catch하도록 핸들링하여 해결하였음.
- APIClient에서 `headers` 매개변수에 Token을 직접 지정했을 때 Authentification이 제대로 이루어지지 않는 것을 확인하고 매 요청마다 `APIClient.credentials()` 함수를 호출하는 것으로 방향 변경

Resolve #47 