### PR TITLE
Simplifying Algorithm

### DIFF
--- a/frontend/src/components/pages/RoomPage/index.js
+++ b/frontend/src/components/pages/RoomPage/index.js
@@ -1,20 +1,15 @@
 import React from 'react'
 
 import { Block, Button, CircularGraph, Graph, List, ListItem, Header } from 'components'
+import { getMemberDebtList, getSimplifiedGraph } from 'services/simplifier'
 
 const RoomPage = props => (
   <div>
     <Header />
     <Block transparent>
-      <Graph graph={{
-        nodes: [
-          { id: "a", label: "A" },
-          { id: "b", label: "B" },
-        ],
-        edges: [
-          { from: "a", to: "b", label: "10,000" },
-        ],
-      }} />
+      <Graph graph={getSimplifiedGraph(
+        getMemberDebtList(props.payments)
+      )} />
     </Block>
     <Block>
       새로운 계산이 생겼다면?

--- a/frontend/src/containers/RoomPage.js
+++ b/frontend/src/containers/RoomPage.js
@@ -27,6 +27,7 @@ class RoomPageContainer extends React.Component {
 
 const mapStateToProps = state => ({
   room: state.room.room,
+  payments: state.room.payments,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/src/services/simplifier/index.js
+++ b/frontend/src/services/simplifier/index.js
@@ -1,0 +1,54 @@
+
+export const getMemberDebt = (payments, memberId) => {
+  return (getMemberDebtList(payments)[memberId] || 0)  // undefined 대응
+}
+
+export const getMemberDebtList = payments => {
+  /* 시간복잡도 O(P + C)
+      where P is Payment 총 개수 &
+            C is Payment 하위에 속한 Credit 총 개수
+   */
+  const result = {}
+  const accumulate = (key, value) => {
+    result[key] = (result[key] || 0) + value
+  }
+
+  payments.forEach(payment => {
+    accumulate(payment.fromWho, -payment.total)  // 내가 낸 돈은 빚에서 탕감
+    payment.credits.forEach(credit => {
+      accumulate(credit.toWho, credit.amount)  // 다른 사람이 내준 돈은 내준 만큼 빚 추가
+    })
+  })
+
+  return result
+}
+
+export const getSimplifiedGraph = debts => {
+  const members = Object.keys(debts).sort(
+    (a, b) => -(debts[a] - debts[b])  // descending by value
+  )
+  const edges = []
+
+  const indice = members.slice()  // 배열 복사
+  while (indice.length) {
+    const first = indice[0], last = indice[indice.length - 1]
+    const amount = Math.min(
+      debts[first], -debts[last]
+    )
+
+    edges.push({ from: first, to: last, label: amount })
+
+    debts[first] -= amount
+    if (debts[first] === 0)
+      indice.splice(0, 1)
+
+    debts[last] += amount
+    if (debts[last] === 0)
+      indice.pop()
+  }
+
+  return {
+    nodes: members.map(id => ({ id, label: id, })),
+    edges,
+  }
+}

--- a/frontend/src/services/simplifier/index.js
+++ b/frontend/src/services/simplifier/index.js
@@ -36,7 +36,7 @@ export const getSimplifiedGraph = debts => {
       debts[first], -debts[last]
     )
 
-    edges.push({ from: first, to: last, label: amount })
+    edges.push({ from: first, to: last, label: String(amount) })
 
     debts[first] -= amount
     if (debts[first] === 0)

--- a/frontend/src/services/simplifier/index.test.js
+++ b/frontend/src/services/simplifier/index.test.js
@@ -90,8 +90,8 @@ describe('getSimplifiedGraph', () => {
         { id: 'c', label: 'c' },
       ],
       edges: [
-        { from: 'a', to: 'c', label: 100 },
-        { from: 'b', to: 'c', label: 100 },
+        { from: 'a', to: 'c', label: '100' },
+        { from: 'b', to: 'c', label: '100' },
       ]
     })
 
@@ -106,9 +106,9 @@ describe('getSimplifiedGraph', () => {
         { id: 'd', label: 'd' },
       ],
       edges: [
-        { from: 'b', to: 'd', label: 202 },
-        { from: 'c', to: 'a', label: 101 },
-        { from: 'c', to: 'e', label: 100 },
+        { from: 'b', to: 'd', label: '202' },
+        { from: 'c', to: 'a', label: '101' },
+        { from: 'c', to: 'e', label: '100' },
       ]
     })
   })

--- a/frontend/src/services/simplifier/index.test.js
+++ b/frontend/src/services/simplifier/index.test.js
@@ -1,0 +1,116 @@
+import { getMemberDebt, getMemberDebtList, getSimplifiedGraph } from '.'
+
+/* payer가 members(본인 포함 가능)를 위해 amount를 지불한 뒤 N빵을 청구하는 경우 */
+const nBbang = (payer, members, amount) => ({
+  fromWho: payer,
+  total: amount,
+  credits: members.map(
+    m => ({ toWho: m, amount: amount / members.length })
+  )
+})
+
+describe('getMemberDebt', () => {
+  it('returns 0 when empty payments were given', () => {
+    expect(getMemberDebt([], 1)).toBe(0)
+  })
+
+  it('returns correct answer', () => {
+    const profit = nBbang(3, [1, 2, 3], 3030)
+    const loss = nBbang(1, [1, 2, 3, 4], 2020)
+
+    expect(getMemberDebt([profit,], 1)).toBe(1010)
+    expect(getMemberDebt([loss,], 1)).toBe(-1515)
+    expect(getMemberDebt([loss, profit,], 1)).toBe(1010-1515)
+    expect(getMemberDebt([loss, loss, profit,], 1)).toBe(1010-2*1515)
+  })
+})
+
+describe('getMemberDebtList', () => {
+  it('returns empty Object when empty payments were given'), () => {
+    expect(getMemberDebtList([])).toEqual({})
+  }
+
+  it('returns correctly', () => {
+    const paymentA = nBbang(3, [1, 2, 3], 3000)
+    const paymentB = nBbang(4, [2, 3, 4], 3600)
+
+    expect(getMemberDebtList([paymentA,])).toEqual({
+      1: 1000, 2: 1000, 3: -2000,
+    })
+    expect(getMemberDebtList([paymentB,])).toEqual({
+      2: 1200, 3: 1200, 4: -2400,
+    })
+    expect(getMemberDebtList([paymentA, paymentB])).toEqual({
+      1: 1000, 2: 2200, 3: -800, 4: -2400,
+    })
+  })
+
+  it('returns valid object whose sum is 0', () => {
+    const memberCount = 5
+    const paymentCount = 10
+
+    const randInt = (min, max) => (
+      Math.floor(Math.random() * (max - min)) + min
+    )
+    const randMember = () => randInt(1, memberCount)
+
+    // 랜덤 거래를 자유롭게 추가
+    const debtList = getMemberDebtList(
+      [...Array(paymentCount).keys()].map(
+        () => randInt(1, 5)
+      ).map(
+        len => nBbang(
+          randMember(),
+          [...Array(len).keys()].map(() => randMember()),
+          randInt(100, 200) * len
+        )
+      )
+    )
+    
+    expect(Object.values(debtList).reduce(
+      (a, b) => a + b, 0
+    )).toBe(0)
+  })
+})
+
+describe('getSimplifiedGraph', () => {
+  it('returns empty graph', () => {
+    expect(getSimplifiedGraph({})).toEqual({
+      nodes: [], edges: [],
+    })
+  })
+
+  it('returns correctly', () => {
+    expect(getSimplifiedGraph(
+      { a: 100, b: 100, c: -200 }
+    )).toEqual({
+      nodes: [
+        { id: 'a', label: 'a' },
+        { id: 'b', label: 'b' },
+        { id: 'c', label: 'c' },
+      ],
+      edges: [
+        { from: 'a', to: 'c', label: 100 },
+        { from: 'b', to: 'c', label: 100 },
+      ]
+    })
+
+    expect(getSimplifiedGraph(
+      { a: -101, b: 202, c: 201, d: -202, e: -100 }
+    )).toEqual({
+      nodes: [
+        { id: 'b', label: 'b' },
+        { id: 'c', label: 'c' },
+        { id: 'e', label: 'e' },
+        { id: 'a', label: 'a' },
+        { id: 'd', label: 'd' },
+      ],
+      edges: [
+        { from: 'b', to: 'd', label: 202 },
+        { from: 'c', to: 'a', label: 101 },
+        { from: 'c', to: 'e', label: 100 },
+      ]
+    })
+  })
+})
+

--- a/frontend/src/store/Room/reducer.js
+++ b/frontend/src/store/Room/reducer.js
@@ -3,6 +3,27 @@ import * as actions from './actions';
 const initialState = {
   /* room: 현재 접속해있는 방의 정보 */
   room: null,
+
+  /* payments: 현재 접속한 방의 거래 정보. 우선 테스트 값 넣어둠. */
+  payments: [
+    {
+      fromWho: 'A',
+      total: 300,
+      credits: [
+        { toWho: 'A', amount: 100 },
+        { toWho: 'B', amount: 100 },
+        { toWho: 'C', amount: 100 },
+      ]
+    },
+    {
+      fromWho: 'B',
+      total: 50,
+      credits: [
+        { toWho: 'A', amount: 50 },
+      ]
+    }
+  ],
+
   /* roomList: UserPage의 방 목록 (해당 User가 접근할 수 있는 방 목록)
    *   - 초기화 이전에는 null
    *   - 초기화 된 이후에는 {roomname, url, owner}의 List로 구성됨


### PR DESCRIPTION
* `services/simplifier` 모듈 만들었습니다.
  - `getMemberDebtList(payments)`는 Payment 모델 정보를 받아 그 사람의 빚(내야할 돈, 음수일 수도 있음)을 계산한 object를 반환합니다.
  - `getSimplifiedGraph(debts)`는 getMemberDebtList의 반환 값을 입력받아 Greedy한 접근 방법을 이용하여 그래프 오브젝트(`nodes`와 `edges` key를 갖고 있는)를 반환합니다.
  - 각 함수의 구체적인 input/output 스펙은 test.js의 것을 참고하시면 되겠습니다.
* `room` store에 `payments` 라는 이름의 속성을 추가하여 RoomPage와 연결했습니다.
* RoomPage의 기존 `<Graph />`에다가 payments props를 연결했습니다.