### PR TITLE
Modify PaymentSerializer & add a test

### DIFF
--- a/backend/src/dutch_broomstick/models.py
+++ b/backend/src/dutch_broomstick/models.py
@@ -38,6 +38,9 @@ class Member(models.Model):
     room = models.ForeignKey(Room, on_delete=models.CASCADE, null=False)
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True) # user is nullable
 
+    def __str__(self):
+        return self.membername
+
 
 class Layer(models.Model):
     number = models.IntegerField()

--- a/backend/src/dutch_broomstick/serializers.py
+++ b/backend/src/dutch_broomstick/serializers.py
@@ -58,22 +58,23 @@ class LayerSerializer(serializers.ModelSerializer):
         fields = ('number', 'layername', 'currency', 'room')
 
 
-class PaymentSerializer(serializers.ModelSerializer):
-    total = serializers.FloatField()
-    layer = serializers.ReadOnlyField(source="layer.id")
-    forWhat = serializers.CharField()
-    fromWho = serializers.ReadOnlyField(source="fromWho.id")
-
-    class Meta:
-        model = Payment
-        fields = ('id', 'total', 'timestamp', 'layer', 'forWhat', 'fromWho')
-
-
 class CreditSerializer(serializers.ModelSerializer):
     amount = serializers.FloatField()
     payment = serializers.ReadOnlyField(source="fromWho.id")
-    toWho = serializers.ReadOnlyField(source="fromWho.id")
+    toWho = serializers.StringRelatedField()
 
     class Meta:
         model = Credit
-        fields = ('id', 'amount', 'payment', 'towho')
+        fields = ('id', 'payment', 'amount', 'toWho')
+
+
+class PaymentSerializer(serializers.ModelSerializer):
+    total = serializers.FloatField()
+    layer = serializers.ReadOnlyField(source="layer.number")
+    forWhat = serializers.CharField()
+    fromWho = serializers.StringRelatedField()
+    credits = CreditSerializer(many=True, source="credit_set")
+
+    class Meta:
+        model = Payment
+        fields = ('id', 'total', 'timestamp', 'layer', 'forWhat', 'fromWho', 'credits')


### PR DESCRIPTION
```
{
  "id": 1,
  "fromWho": "유석",
  "forWhat": "",
  "timestamp": "2019-06-12T16:11:01",
  "layer": 0,
  "total": 1.0,
  "credits": [
    {
      "toWho": "정민",
      "amount": 1.0
    }
  ]
}
```

위와 같은 형식으로 Serialization이 이뤄지도록 PaymentSerializer을 수정했습니다.