### PR TITLE
User Story 8 (RoomCreatePage)

### DIFF
--- a/frontend/src/components/organisms/RoomCreateForm/index.js
+++ b/frontend/src/components/organisms/RoomCreateForm/index.js
@@ -5,7 +5,7 @@ import { toastr } from 'react-redux-toastr'
 import { Block, Button, Input, List, ListItem } from 'components'
 
 const RoomCreateForm = props => {
-  const { handleSubmit, newMemberName } = props;
+  const { username, handleSubmit, newMemberName } = props;
   const { pushMember, resetField } = props;
   const fields = props.users || [];
 
@@ -23,6 +23,7 @@ const RoomCreateForm = props => {
       <Block>
         멤버 목록<br />
         <List>
+          <ListItem title={username} description="방장" />
           {fields.map((member, index) => (
             <Field
               key={index}
@@ -51,8 +52,9 @@ const RoomCreateForm = props => {
       return
     }
     
-    if (fields.filter(u => (u.name === newMemberName)).length) {
+    if (username === newMemberName || fields.filter(u => (u.name === newMemberName)).length) {
       showError("중복된 별명입니다.")
+      return
     }
 
     pushMember({ name: newMemberName, })

--- a/frontend/src/components/organisms/RoomCreateForm/index.js
+++ b/frontend/src/components/organisms/RoomCreateForm/index.js
@@ -7,7 +7,7 @@ import { Block, Button, Input, List, ListItem } from 'components'
 const RoomCreateForm = props => {
   const { username, handleSubmit, newMemberName } = props;
   const { pushMember, resetField } = props;
-  const fields = props.users || [];
+  const fields = props.members || [];
 
   const ListItemWrapper = onRemove => {
     return ({ input }) => (
@@ -87,7 +87,7 @@ const RoomCreateForm = props => {
           멤버 추가
         </Button>
       </Block>
-      <FieldArray name="users" component={renderMembers} />
+      <FieldArray name="members" component={renderMembers} />
     </form>
   );
 };

--- a/frontend/src/containers/RoomCreateForm.js
+++ b/frontend/src/containers/RoomCreateForm.js
@@ -19,11 +19,11 @@ const selector = formValueSelector(FORM_NAME)
 const mapStateToProps = state => ({
   username: state.user.username,
   newMemberName: selector(state, 'newMemberName'),
-  users: selector(state, 'users'),
+  members: selector(state, 'members'),
 })
 
 const mapDispatchToProps = dispatch => ({
-  pushMember: value => dispatch(arrayPush(FORM_NAME, 'users', value)),
+  pushMember: value => dispatch(arrayPush(FORM_NAME, 'members', value)),
   resetField: field => dispatch(change(FORM_NAME, field, null)),
 })
 
@@ -31,9 +31,9 @@ export default connect(mapStateToProps, mapDispatchToProps)(
   reduxForm({
     form: FORM_NAME,
     onSubmit(values, dispatch, props) {
-      const { roomname, usernames } = values
+      const { roomname, members } = values
       const { username, token } = props  // username means ownername
-      dispatch(roomCreateRequest(roomname, usernames, username, token))
+      dispatch(roomCreateRequest(roomname, members, username, token))
     }
   })(RoomCreateFormContainer)
 )

--- a/frontend/src/containers/RoomCreateForm.js
+++ b/frontend/src/containers/RoomCreateForm.js
@@ -17,6 +17,7 @@ const RoomCreateFormContainer = props => {
 const selector = formValueSelector(FORM_NAME)
 
 const mapStateToProps = state => ({
+  username: state.user.username,
   newMemberName: selector(state, 'newMemberName'),
   users: selector(state, 'users'),
 })

--- a/frontend/src/containers/RoomCreatePage.js
+++ b/frontend/src/containers/RoomCreatePage.js
@@ -4,17 +4,16 @@ import { RoomCreatePage } from 'components'
 import { Redirect } from 'react-router-dom'
 
 const RoomCreatePageContainer = (props) => {
-  const { room } = props
-  
-  if( room ){
-    return(
-      <Redirect to={`/room/${room.roomname}/`}/>
-    )
+  const { room, username } = props
+
+  if ( !username ) {
+    return <Redirect to="/" />
+  }
+  else if( room ) {
+    return <Redirect to={`/room/${room.url}/`}/>
   } 
   else {
-    return (
-      <RoomCreatePage {...props} />
-    )
+    return <RoomCreatePage {...props} />
   }
 }
 

--- a/frontend/src/store/Room/actions.js
+++ b/frontend/src/store/Room/actions.js
@@ -2,10 +2,10 @@
 export const ROOM_CREATE_REQUEST = "ROOM_CREATE_REQUEST"
 export const ROOM_CREATE_SUCCESS = "ROOM_CREATE_SUCCESS"
 
-export const roomCreateRequest = (roomname, users, username, token) => ({
+export const roomCreateRequest = (roomname, members, username, token) => ({
   type: ROOM_CREATE_REQUEST,
   roomname,
-  users,
+  members,
   username,
   token,
 })

--- a/frontend/src/store/Room/sagas.js
+++ b/frontend/src/store/Room/sagas.js
@@ -11,14 +11,14 @@ import * as actions from './actions'
 
 /* Room Create Request */
 
-function* roomCreateRequest({ roomname, users, username, token }){
+function* roomCreateRequest({ roomname, members, username, token }){
   try {
     const room = yield api.post(`/users/${username}/rooms/`, { roomname }, { token })
-    const createMember = data => api.post(`/rooms/${room.url}/members/`, data, { token })
+    const createMember = data => api.post(`/rooms/${room.url}/members/`, { account: "", ...data }, { token })
 
     yield createMember({ user: username, membername: username })  // make owner
-    for (user of users) {
-      yield createMember({ membername: user })
+    for (let member of members) {
+      yield createMember({ membername: member.name })
     }
 
     toastr.light(

--- a/frontend/src/store/Room/sagas.js
+++ b/frontend/src/store/Room/sagas.js
@@ -14,6 +14,13 @@ import * as actions from './actions'
 function* roomCreateRequest({ roomname, users, username, token }){
   try {
     const room = yield api.post(`/users/${username}/rooms/`, { roomname }, { token })
+    const createMember = data => api.post(`/rooms/${room.url}/members/`, data, { token })
+
+    yield createMember({ user: username, membername: username })  // make owner
+    for (user of users) {
+      yield createMember({ membername: user })
+    }
+
     toastr.light(
       `${room.roomname}`, '새로운 방이 만들어졌습니다!',
       { icon: 'success', status: 'success', }


### PR DESCRIPTION
## 프론트엔드
* UI 개선
![https://pasteboard.co/IjcKR7l.png](https://pasteboard.co/IjcKR7l.png)
  - 방장은 삭제가 불가능한 ListItem으로 독립적으로 존재 (기본값: 방장의 Username)
  - 남은 이슈 : 멤버 이름 입력란에서 엔터를 쳐도 방 생성
* RoomCreateForm.users를 RoomCreateForm.members로 이름 변경
* 멤버 추가 로직을 백엔드에 연동
* 리다이렉션 로직 수정
  - 방 생성 성공시 `/rooms/:roomname` 대신 `/rooms/:url`로 이동
  - 로그인 되지 않은 상태에서는 로그인 페이지로 강제 리다이렉트
