### PR TITLE
User Story 13 (Show member list on RoomPage)

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -22,7 +22,7 @@ const App = () => {
     <ThemeProvider theme={theme}>
       <Switch>
         <Route path="/" component={MainPage} exact />
-        <Route path="/room/:room_id" component={RoomPage} />
+        <Route path="/room/:room_id/" component={RoomPage} exact />
         <Route path="/signup/" component={SignUpPage} exact />
         <Route path="/user/" component={UserPage} exact />
         <Route path="/user/setting/" component={UserInfoPage} exact  />

--- a/frontend/src/components/atoms/Graph/index.js
+++ b/frontend/src/components/atoms/Graph/index.js
@@ -45,6 +45,7 @@ const SquareGraph = props => {
               },
             },
           }}
+          events={props.events}
           />
       </Content>
     </Wrapper>
@@ -53,6 +54,7 @@ const SquareGraph = props => {
 
 SquareGraph.propTypes = {
   graph: PropTypes.object.isRequired,
+  events: PropTypes.object,
 }
 
 export default SquareGraph

--- a/frontend/src/components/organisms/RoomCreateForm/index.js
+++ b/frontend/src/components/organisms/RoomCreateForm/index.js
@@ -5,7 +5,7 @@ import { toastr } from 'react-redux-toastr'
 import { Block, Button, Input, List, ListItem } from 'components'
 
 const RoomCreateForm = props => {
-  const { handleSubmit, newMemberName } = props;
+  const { username, handleSubmit, newMemberName } = props;
   const { pushMember, resetField } = props;
   const fields = props.users || [];
 
@@ -23,6 +23,7 @@ const RoomCreateForm = props => {
       <Block>
         멤버 목록<br />
         <List>
+          <ListItem title={username} description="방장" />
           {fields.map((member, index) => (
             <Field
               key={index}
@@ -51,8 +52,9 @@ const RoomCreateForm = props => {
       return
     }
     
-    if (fields.filter(u => (u.name === newMemberName)).length) {
+    if (username === newMemberName || fields.filter(u => (u.name === newMemberName)).length) {
       showError("중복된 별명입니다.")
+      return
     }
 
     pushMember({ name: newMemberName, })

--- a/frontend/src/components/organisms/RoomCreateForm/index.js
+++ b/frontend/src/components/organisms/RoomCreateForm/index.js
@@ -7,7 +7,7 @@ import { Block, Button, Input, List, ListItem } from 'components'
 const RoomCreateForm = props => {
   const { username, handleSubmit, newMemberName } = props;
   const { pushMember, resetField } = props;
-  const fields = props.users || [];
+  const fields = props.members || [];
 
   const ListItemWrapper = onRemove => {
     return ({ input }) => (
@@ -87,7 +87,7 @@ const RoomCreateForm = props => {
           멤버 추가
         </Button>
       </Block>
-      <FieldArray name="users" component={renderMembers} />
+      <FieldArray name="members" component={renderMembers} />
     </form>
   );
 };

--- a/frontend/src/components/pages/RoomPage/index.js
+++ b/frontend/src/components/pages/RoomPage/index.js
@@ -1,33 +1,54 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { Block, Button, CircularGraph, Graph, List, ListItem, Header } from 'components'
 import { getMemberDebtList, getSimplifiedGraph } from 'services/simplifier'
 
-const RoomPage = props => (
-  <div>
-    <Header />
-    <Block transparent>
-      <Graph graph={getSimplifiedGraph(
-        getMemberDebtList(props.payments)
-      )} />
-    </Block>
-    <Block>
-      새로운 계산이 생겼다면?
-      <Button>내역 추가</Button>
-    </Block>
-    <Block>
-      <p>계산 내역</p>
-      <List>
-        <ListItem title="삼겹살" description="35,000원" />
-        <ListItem title="노래방" description="25,000원" />
-        <ListItem title="카페" description="30,000원" />
-      </List>
-      {/* 계산 내역 리스트 */}
-    </Block>
-    <Block transparent>
-      <a>로그아웃</a>
-    </Block>
-  </div>
-)
+const RoomPage = props => {
+  const { room, onClickMember } = props
+  if (!room) return <Block transparent>Loading...</Block>
+  
+  // const graph = getSimplifiedGraph(getMemberDebtList(props.payments))
+  const graph = {
+    nodes: room.members.map(m => ({ id: m.membername, label: m.membername })),
+    edges: [],
+  }
+
+  const events = {
+    selectNode(evt) {
+      const nodeId = evt.nodes.find(() => true)
+      onClickMember(room.members.find(m => m.membername === nodeId))
+    }
+  }
+
+  return (
+    <div>
+      <Header />
+      <Block transparent>
+        <Graph graph={graph} events={events} />
+      </Block>
+      <Block>
+        새로운 계산이 생겼다면?
+        <Button>내역 추가</Button>
+      </Block>
+      <Block>
+        <p>계산 내역</p>
+        <List>
+          <ListItem title="삼겹살" description="35,000원" />
+          <ListItem title="노래방" description="25,000원" />
+          <ListItem title="카페" description="30,000원" />
+        </List>
+        {/* 계산 내역 리스트 */}
+      </Block>
+      <Block transparent>
+        <a>로그아웃</a>
+      </Block>
+    </div>
+  )
+}
+
+RoomPage.propTypes = {
+  onClickMember: PropTypes.func.isRequired,
+}
 
 export default RoomPage

--- a/frontend/src/containers/RoomCreateForm.js
+++ b/frontend/src/containers/RoomCreateForm.js
@@ -19,11 +19,11 @@ const selector = formValueSelector(FORM_NAME)
 const mapStateToProps = state => ({
   username: state.user.username,
   newMemberName: selector(state, 'newMemberName'),
-  users: selector(state, 'users'),
+  members: selector(state, 'members'),
 })
 
 const mapDispatchToProps = dispatch => ({
-  pushMember: value => dispatch(arrayPush(FORM_NAME, 'users', value)),
+  pushMember: value => dispatch(arrayPush(FORM_NAME, 'members', value)),
   resetField: field => dispatch(change(FORM_NAME, field, null)),
 })
 
@@ -31,9 +31,9 @@ export default connect(mapStateToProps, mapDispatchToProps)(
   reduxForm({
     form: FORM_NAME,
     onSubmit(values, dispatch, props) {
-      const { roomname, usernames } = values
+      const { roomname, members } = values
       const { username, token } = props  // username means ownername
-      dispatch(roomCreateRequest(roomname, usernames, username, token))
+      dispatch(roomCreateRequest(roomname, members, username, token))
     }
   })(RoomCreateFormContainer)
 )

--- a/frontend/src/containers/RoomCreateForm.js
+++ b/frontend/src/containers/RoomCreateForm.js
@@ -17,6 +17,7 @@ const RoomCreateFormContainer = props => {
 const selector = formValueSelector(FORM_NAME)
 
 const mapStateToProps = state => ({
+  username: state.user.username,
   newMemberName: selector(state, 'newMemberName'),
   users: selector(state, 'users'),
 })

--- a/frontend/src/containers/RoomCreatePage.js
+++ b/frontend/src/containers/RoomCreatePage.js
@@ -4,17 +4,16 @@ import { RoomCreatePage } from 'components'
 import { Redirect } from 'react-router-dom'
 
 const RoomCreatePageContainer = (props) => {
-  const { room } = props
-  
-  if( room ){
-    return(
-      <Redirect to={`/room/${room.roomname}/`}/>
-    )
+  const { room, username } = props
+
+  if ( !username ) {
+    return <Redirect to="/" />
+  }
+  else if( room ) {
+    return <Redirect to={`/room/${room.url}/`}/>
   } 
   else {
-    return (
-      <RoomCreatePage {...props} />
-    )
+    return <RoomCreatePage {...props} />
   }
 }
 

--- a/frontend/src/containers/RoomPage.js
+++ b/frontend/src/containers/RoomPage.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { RoomPage } from 'components'
 
-import { roomGetRequest, roomLeave } from 'store/actions'
+import { roomGetRequest, roomLeave, roomSetMember } from 'store/actions'
 
 class RoomPageContainer extends React.Component {
   componentDidMount() {
@@ -13,7 +14,13 @@ class RoomPageContainer extends React.Component {
   }
 
   render() {
-    if (this.props.room) {
+    const { room, member } = this.props
+
+    if (member) {
+      return <Redirect to={`/room/${room.url}/${member.id}/`} />
+    }
+    
+    if (room) {
       document.title = `${this.props.room.roomname} - Dutch Broomstick`
     }
 
@@ -27,12 +34,14 @@ class RoomPageContainer extends React.Component {
 
 const mapStateToProps = state => ({
   room: state.room.room,
+  member: state.room.member,
   payments: state.room.payments,
 })
 
 const mapDispatchToProps = dispatch => ({
   onGetRoom: (url) => dispatch(roomGetRequest(url)),
-  onLeave: () => dispatch(roomLeave())
+  onLeave: () => dispatch(roomLeave()),
+  onClickMember: member => dispatch(roomSetMember(member)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(RoomPageContainer)

--- a/frontend/src/store/Room/actions.js
+++ b/frontend/src/store/Room/actions.js
@@ -75,3 +75,11 @@ export const roomGetFailed = (error) => ({
 export const ROOM_LEAVE = "ROOM_LEAVE"
 
 export const roomLeave = () => ({ type: ROOM_LEAVE })
+
+
+export const ROOM_SET_MEMBER = "ROOM_SET_MEMBER"
+
+export const roomSetMember = member => ({
+  type: ROOM_SET_MEMBER,
+  member,
+})

--- a/frontend/src/store/Room/actions.js
+++ b/frontend/src/store/Room/actions.js
@@ -2,10 +2,10 @@
 export const ROOM_CREATE_REQUEST = "ROOM_CREATE_REQUEST"
 export const ROOM_CREATE_SUCCESS = "ROOM_CREATE_SUCCESS"
 
-export const roomCreateRequest = (roomname, users, username, token) => ({
+export const roomCreateRequest = (roomname, members, username, token) => ({
   type: ROOM_CREATE_REQUEST,
   roomname,
-  users,
+  members,
   username,
   token,
 })

--- a/frontend/src/store/Room/reducer.js
+++ b/frontend/src/store/Room/reducer.js
@@ -28,7 +28,13 @@ const initialState = {
    *   - 초기화 이전에는 null
    *   - 초기화 된 이후에는 {roomname, url, owner}의 List로 구성됨
    */
-  roomList: null,    
+  roomList: null,
+
+  /* member: 사용자가 현재 보고 있는 IndividualPage의 주인
+   *   - 초깃값은 null
+   *   - Object({id, membername, account})
+   */
+  member: null,
 }
 
 const roomReducer = (state = initialState, action) => {
@@ -70,6 +76,12 @@ const roomReducer = (state = initialState, action) => {
       return {
         ...state,
         room: null,
+        member: null,
+      }
+    case actions.ROOM_SET_MEMBER:
+      return {
+        ...state,
+        member: action.member,
       }
     default:
       return state

--- a/frontend/src/store/Room/sagas.js
+++ b/frontend/src/store/Room/sagas.js
@@ -11,14 +11,14 @@ import * as actions from './actions'
 
 /* Room Create Request */
 
-function* roomCreateRequest({ roomname, users, username, token }){
+function* roomCreateRequest({ roomname, members, username, token }){
   try {
     const room = yield api.post(`/users/${username}/rooms/`, { roomname }, { token })
-    const createMember = data => api.post(`/rooms/${room.url}/members/`, data, { token })
+    const createMember = data => api.post(`/rooms/${room.url}/members/`, { account: "", ...data }, { token })
 
     yield createMember({ user: username, membername: username })  // make owner
-    for (user of users) {
-      yield createMember({ membername: user })
+    for (let member of members) {
+      yield createMember({ membername: member.name })
     }
 
     toastr.light(

--- a/frontend/src/store/Room/sagas.js
+++ b/frontend/src/store/Room/sagas.js
@@ -14,6 +14,13 @@ import * as actions from './actions'
 function* roomCreateRequest({ roomname, users, username, token }){
   try {
     const room = yield api.post(`/users/${username}/rooms/`, { roomname }, { token })
+    const createMember = data => api.post(`/rooms/${room.url}/members/`, data, { token })
+
+    yield createMember({ user: username, membername: username })  // make owner
+    for (user of users) {
+      yield createMember({ membername: user })
+    }
+
     toastr.light(
       `${room.roomname}`, '새로운 방이 만들어졌습니다!',
       { icon: 'success', status: 'success', }

--- a/frontend/src/store/Room/sagas.js
+++ b/frontend/src/store/Room/sagas.js
@@ -54,6 +54,7 @@ function* watchRoomListRequest() {
 function* getRequest({ url }) {
   try {
     const room = yield api.get(`/rooms/${url}/`)
+    room.members = yield api.get(`/rooms/${url}/members/`)
     yield put(actions.roomGetSuccess(room))
   } catch(e) {
     yield put(actions.roomGetFailed(e))


### PR DESCRIPTION
#55 PR의 연장선입니다

1. onGetRoom() 에서 멤버 정보도 같이 불러오도록 sagas 로직 수정
2. 1을 토대로 RoomPage Graph의 노드 구성
3. RoomPage Graph 노드를 클릭할 때 IndividualPage로 Redirect
4. 2를 구현하기 위해 roomSetMember() 액션 추가, room store에 member라는 Object 변수 추가
5. App.js Router에 RoomPage를 exact path일 때만 접속 가능하도록 수정